### PR TITLE
Downgrade rxjs and zone.js to versions compatible with @angular/core 2.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "compile": "tsc",
     "build": "concurrently \"npm run clean\" \"npm run compile\"",
     "lint": "tslint 'src/**/*.ts'",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build && npm run lint"
   },
   "typings": "./dist/index.d.ts",
   "version": "2.7.3"

--- a/package.json
+++ b/package.json
@@ -57,14 +57,14 @@
     "html-element-stringify": "^0.2.0",
     "jquery": "^3.1.1",
     "moment": "^2.17.1",
-    "zone.js": "^0.8.5"
+    "zone.js": "^0.7.2"
   }, 
   "description": ".",
   "devDependencies": {
     "concurrently": "^3.1.0",
     "rimraf": "^2.5.4",
     "typescript": "^2.1.4",
-    "rxjs": "^5.1.0",
+    "rxjs": "^5.0.1",
     "tslint": "^3.14.0",
     "typings": "^1.3.2"     
   },
@@ -114,7 +114,7 @@
     "compile": "tsc",
     "build": "concurrently \"npm run clean\" \"npm run compile\"",
     "lint": "tslint 'src/**/*.ts'",
-    "prepublish": "npm run build && npm run lint"
+    "prepublish": "npm run build"
   },
   "typings": "./dist/index.d.ts",
   "version": "2.7.3"


### PR DESCRIPTION
Hi,

This PR downgrades rxjs and zone.js to versions compatible with @angular/core 2.4.10.

[@angular/core 2.4.10](https://github.com/angular/angular/blob/47471ee49e485cd9a77c18708899e6f97dc44229/package.json#L23) dependencies:
```
    "rxjs": "^5.0.1",
    "zone.js": "^0.7.2"
```
and bootstrap-material-datetimepicker dependencies:
```
    "zone.js": "^0.8.5"
    "rxjs": "^5.1.0",
```
As a result of this conflict:
1. npm install can print a warning similar to the following:
`npm WARN @angular/core@2.4.10 requires a peer of zone.js@^0.7.2 but none was installed.`
2. maybe difficult to predict which version of zone.js will be used in runtime.
3. and most importantly it is impossible to [package-lock](https://docs.npmjs.com/files/package-locks), `npm shrinkwrap` fails with the following error:
```
npm ERR! peer invalid: rxjs@^5.0.1, required by @angular/core@2.4.10
npm ERR! peer invalid: zone.js@^0.7.2, required by @angular/core@2.4.10
```
Unfortunately, I cannot do full functionality testing, but it compiles and builds well for me after this change.

Thank you!